### PR TITLE
Fix graphs for initial deckbrowser page render

### DIFF
--- a/src/deckbrowser.py
+++ b/src/deckbrowser.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from anki.hooks import wrap
 
-from aqt.gui_hooks import deck_browser_will_render_content, profile_did_open, profile_will_close
+from aqt.gui_hooks import deck_browser_will_render_content, profile_will_close, main_window_did_init, deck_browser_did_render
 from aqt.deckbrowser import DeckBrowser
 
 from .utils import make_graph_js, get_active_deckbrowser_graphs, add_browser_search_link
@@ -24,8 +24,12 @@ def add_deckbrowser_hook():
 def remove_deckbrowser_hook():
     deck_browser_will_render_content.remove(add_graphs_to_deckbrowser)
 
+def handle_initial_render(self):
+    add_deckbrowser_hook()
+    deck_browser_did_render.remove(handle_initial_render)
+    self.refresh()
 
 def init_deckbrowser():
-    profile_did_open.append(add_deckbrowser_hook)
+    deck_browser_did_render.append(handle_initial_render)
     profile_will_close.append(remove_deckbrowser_hook)
     DeckBrowser._linkHandler = wrap(DeckBrowser._linkHandler, add_browser_search_link, "before")


### PR DESCRIPTION
Handle graphs with initial deckbrowser render. It looks like `profile_did_open` hook is fired after the first rendering, so the graphs don't render when first opening Anki. This PR solves the issue by using `deck_browser_did_render` hook instead and re-drawing the decks page after setting deckbrowser hook for graphs.